### PR TITLE
fix(tv): close out D-pad navigation bugs across home, explore, details, settings (PR1 + PR2)

### DIFF
--- a/lib/core/widgets/update_dialog.dart
+++ b/lib/core/widgets/update_dialog.dart
@@ -58,6 +58,7 @@ class UpdateDialog extends ConsumerWidget {
             ),
           if (updateState is! UpdateDownloading)
             FilledButton(
+              autofocus: true,
               onPressed: () {
                 ref
                     .read(updateControllerProvider.notifier)

--- a/lib/features/details/presentation/details_screen.dart
+++ b/lib/features/details/presentation/details_screen.dart
@@ -143,35 +143,46 @@ class _DetailsScreenState extends ConsumerState<DetailsScreen> {
                 ],
               ),
             ),
-            leading: CustomButton(
-              shape: const CircleBorder(),
-              backgroundColor: Colors.black45,
-              onPressed: () => context.pop(),
-              child: const Icon(
-                Icons.arrow_back_rounded,
-                color: Colors.white,
+            // AppBar buttons are removed from D-pad / Tab traversal so they
+            // don't get picked as the nearest target from content in the body
+            // (otherwise pressing Up/Left/Right from an episode card can jump
+            // here unexpectedly). Users navigate back via the hardware Back
+            // key on TV remotes. They're still clickable with mouse / touch.
+            leading: Focus(
+              descendantsAreTraversable: false,
+              child: CustomButton(
+                shape: const CircleBorder(),
+                backgroundColor: Colors.black45,
+                onPressed: () => context.pop(),
+                child: const Icon(
+                  Icons.arrow_back_rounded,
+                  color: Colors.white,
+                ),
               ),
             ),
             actions: [
-              IconButton(
-                icon: Icon(
-                  isBookmarked
-                      ? Icons.bookmark_rounded
-                      : Icons.bookmark_border_rounded,
-                  color: isBookmarked
-                      ? Theme.of(context).colorScheme.primary
-                      : Colors.white,
-                ),
-                onPressed: () {
-                  if (isBookmarked) {
-                    libraryNotifier.removeItem(item.url);
-                  } else {
-                    libraryNotifier.addItem(item);
-                  }
-                },
-                style: IconButton.styleFrom(
-                  backgroundColor: Colors.black45,
-                  foregroundColor: Colors.white,
+              Focus(
+                descendantsAreTraversable: false,
+                child: IconButton(
+                  icon: Icon(
+                    isBookmarked
+                        ? Icons.bookmark_rounded
+                        : Icons.bookmark_border_rounded,
+                    color: isBookmarked
+                        ? Theme.of(context).colorScheme.primary
+                        : Colors.white,
+                  ),
+                  onPressed: () {
+                    if (isBookmarked) {
+                      libraryNotifier.removeItem(item.url);
+                    } else {
+                      libraryNotifier.addItem(item);
+                    }
+                  },
+                  style: IconButton.styleFrom(
+                    backgroundColor: Colors.black45,
+                    foregroundColor: Colors.white,
+                  ),
                 ),
               ),
               const SizedBox(width: 8),

--- a/lib/features/details/presentation/widgets/details_layout_widgets.dart
+++ b/lib/features/details/presentation/widgets/details_layout_widgets.dart
@@ -10,6 +10,8 @@ import 'package:skystream/core/domain/entity/multimedia_item.dart';
 import 'package:skystream/core/storage/history_repository.dart';
 import 'package:skystream/core/utils/layout_constants.dart';
 import 'package:skystream/shared/widgets/custom_widgets.dart';
+import '../../../library/presentation/library_provider.dart';
+import '../../../library/presentation/library_state.dart';
 import '../details_controller.dart';
 import 'package:skystream/core/extensions/extension_manager.dart';
 import 'package:skystream/core/services/download_service.dart';
@@ -355,6 +357,47 @@ class DetailsActionButtons extends HookConsumerWidget {
       );
     }
 
+    // Bookmark — gives D-pad users a focusable target. The AppBar's bookmark
+    // icon is excluded from traversal so content navigation doesn't escape
+    // upward; this is its replacement.
+    final isBookmarked = ref.watch(
+      libraryProvider.select(
+        (state) =>
+            state is LibrarySuccess &&
+            state.items.any((i) => i.url == item.url),
+      ),
+    );
+    final bookmarkBtn = CustomButton(
+      isPrimary: false,
+      isOutlined: true,
+      onPressed: () {
+        final notifier = ref.read(libraryProvider.notifier);
+        if (isBookmarked) {
+          notifier.removeItem(item.url);
+        } else {
+          notifier.addItem(details ?? item);
+        }
+      },
+      child: Padding(
+        padding: btnPadding,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              isBookmarked
+                  ? Icons.bookmark_rounded
+                  : Icons.bookmark_border_rounded,
+              color: isBookmarked
+                  ? Theme.of(context).colorScheme.primary
+                  : null,
+            ),
+            const SizedBox(width: LayoutConstants.spacingXs),
+            Text(AppLocalizations.of(context)!.library),
+          ],
+        ),
+      ),
+    );
+
     if (vertical) {
       return Column(
         crossAxisAlignment: CrossAxisAlignment.stretch,
@@ -365,6 +408,8 @@ class DetailsActionButtons extends HookConsumerWidget {
             const SizedBox(height: LayoutConstants.spacingSm),
             downloadBtn,
           ],
+          const SizedBox(height: LayoutConstants.spacingSm),
+          bookmarkBtn,
         ],
       );
     }
@@ -382,6 +427,8 @@ class DetailsActionButtons extends HookConsumerWidget {
                 const SizedBox(width: LayoutConstants.spacingSm),
                 Expanded(child: downloadBtn),
               ],
+              const SizedBox(width: LayoutConstants.spacingSm),
+              Expanded(child: bookmarkBtn),
             ],
           ),
         ),

--- a/lib/features/details/presentation/widgets/episode_card.dart
+++ b/lib/features/details/presentation/widgets/episode_card.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:background_downloader/background_downloader.dart';
@@ -98,26 +99,115 @@ class EpisodeCard extends HookConsumerWidget {
       return null;
     }, [episode.url, isDownloading]);
 
-    return InkWell(
-      onTap: () => ref
-          .read(detailsControllerProvider(parentItem.url).notifier)
-          .handlePlayPress(context, parentItem, specificEpisode: episode),
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        width: width,
-        decoration: BoxDecoration(
-          color: Theme.of(context).colorScheme.surfaceContainerLow,
-          borderRadius: BorderRadius.circular(12.0),
-          border: Border.all(
-            color: Theme.of(context).dividerColor.withValues(
-              alpha: Theme.of(context).brightness == Brightness.dark
-                  ? 0.1
-                  : 0.5,
+    final isFocused = useState(false);
+    final downloadFocusNode = useFocusNode(debugLabel: 'ep_download');
+    final bodyFocusNode = useFocusNode(debugLabel: 'ep_body');
+    final primary = Theme.of(context).colorScheme.primary;
+
+    void triggerDownload() {
+      if (downloadedFile != null) {
+        DownloadManagementDialog.show(
+          context,
+          details ?? parentItem,
+          downloadedFile,
+          episode: episode,
+        );
+      } else if (isDownloading) {
+        DownloadProgressDialog.show(
+          context,
+          '${parentItem.title} - ${episode.name}',
+          episode.url,
+        );
+      } else {
+        ref
+            .read(downloadLauncherProvider)
+            .launch(context, parentItem, episodeUrl: episode.url);
+      }
+    }
+
+    return Focus(
+      // Passive observer — let the inner InkWell be the real focus target so
+      // OK plays and Right can traverse into the download icon (a descendant).
+      canRequestFocus: false,
+      skipTraversal: true,
+      onFocusChange: (f) {
+        isFocused.value = f;
+        if (f) {
+          // Center the focused episode in the viewport when reachable.
+          WidgetsBinding.instance.addPostFrameCallback((_) {
+            final ctx = FocusManager.instance.primaryFocus?.context;
+            final ro = ctx?.findRenderObject();
+            if (ctx != null && ctx.mounted && ro != null) {
+              Scrollable.maybeOf(ctx)?.position.ensureVisible(
+                    ro,
+                    alignment: 0.5,
+                    duration: const Duration(milliseconds: 380),
+                    curve: Curves.fastOutSlowIn,
+                  );
+            }
+          });
+        }
+      },
+      // Reserved key bindings on a focused episode pill:
+      //   • Menu (≡) → trigger download (start / open progress / manage)
+      //   • Long-press OK (key repeat on select/enter) → same as Menu
+      //   • Right arrow (when body is focused) → focus the download icon
+      // OK / Enter / Space still play the episode (via the InkWell).
+      onKeyEvent: (node, event) {
+        final isMenu = event.logicalKey == LogicalKeyboardKey.contextMenu ||
+            event.logicalKey == LogicalKeyboardKey.f10;
+        if (event is KeyDownEvent && isMenu) {
+          triggerDownload();
+          return KeyEventResult.handled;
+        }
+        if (event is KeyRepeatEvent &&
+            (event.logicalKey == LogicalKeyboardKey.select ||
+                event.logicalKey == LogicalKeyboardKey.enter)) {
+          triggerDownload();
+          return KeyEventResult.handled;
+        }
+        // No explicit Right handling here — let Flutter's default
+        // directional traversal pick the right target. In multi-column
+        // grids that's the next card; in single-column layouts users can
+        // press Menu (or long-press OK, both handled above) for download.
+        return KeyEventResult.ignored;
+      },
+      child: InkWell(
+        focusNode: bodyFocusNode,
+        onTap: () => ref
+            .read(detailsControllerProvider(parentItem.url).notifier)
+            .handlePlayPress(context, parentItem, specificEpisode: episode),
+        borderRadius: BorderRadius.circular(12),
+        child: AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          width: width,
+          decoration: BoxDecoration(
+            color: isFocused.value
+                ? primary.withValues(alpha: 0.18)
+                : Theme.of(context).colorScheme.surfaceContainerLow,
+            borderRadius: BorderRadius.circular(12.0),
+            border: Border.all(
+              color: isFocused.value
+                  ? primary
+                  : Theme.of(context).dividerColor.withValues(
+                      alpha: Theme.of(context).brightness == Brightness.dark
+                          ? 0.1
+                          : 0.5,
+                    ),
+              width: isFocused.value ? 2 : 1,
             ),
+            boxShadow: isFocused.value
+                ? [
+                    BoxShadow(
+                      color: primary.withValues(alpha: 0.45),
+                      blurRadius: 14,
+                      spreadRadius: 1,
+                    ),
+                  ]
+                : null,
           ),
-        ),
-        clipBehavior: Clip.antiAlias,
-        padding: const EdgeInsets.all(LayoutConstants.spacingSm),
+          clipBehavior: Clip.antiAlias,
+          padding: const EdgeInsets.all(LayoutConstants.spacingSm),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
@@ -139,6 +229,10 @@ class EpisodeCard extends HookConsumerWidget {
                   ),
                 ),
                 const SizedBox(width: LayoutConstants.spacingXs),
+                // Download icon — uses an explicit FocusNode so the parent
+                // onKeyEvent can force focus here from the body. Left from
+                // the icon returns focus to the body via this widget's own
+                // onKeyEvent.
                 _buildActionButtons(
                   context,
                   ref,
@@ -147,6 +241,8 @@ class EpisodeCard extends HookConsumerWidget {
                   downloadProgress,
                   downloadProgressData,
                   details,
+                  downloadFocusNode,
+                  bodyFocusNode,
                 ),
               ],
             ),
@@ -170,11 +266,40 @@ class EpisodeCard extends HookConsumerWidget {
             ],
           ],
         ),
+        ),
       ),
     );
   }
 
   Widget _buildActionButtons(
+    BuildContext context,
+    WidgetRef ref,
+    File? downloadedFile,
+    bool isDownloading,
+    double downloadProgress,
+    DownloadProgressData? downloadProgressData,
+    MultimediaItem? details,
+    FocusNode focusNode,
+    FocusNode bodyFocusNode,
+  ) {
+    final raw = _buildRawActionButton(
+      context,
+      ref,
+      downloadedFile,
+      isDownloading,
+      downloadProgress,
+      downloadProgressData,
+      details,
+    );
+    if (raw == null) return const SizedBox.shrink();
+    return _FocusableActionWrapper(
+      focusNode: focusNode,
+      bodyFocusNode: bodyFocusNode,
+      child: raw,
+    );
+  }
+
+  Widget? _buildRawActionButton(
     BuildContext context,
     WidgetRef ref,
     File? downloadedFile,
@@ -343,6 +468,68 @@ class EpisodeCard extends HookConsumerWidget {
           ),
         ),
       ],
+    );
+  }
+}
+
+/// Wraps the small download icon so D-pad / Tab focus is unmistakable when it
+/// has focus (the IconButton's default focus ring is too subtle on TV).
+class _FocusableActionWrapper extends StatefulWidget {
+  final Widget child;
+  final FocusNode focusNode;
+  final FocusNode bodyFocusNode;
+  const _FocusableActionWrapper({
+    required this.child,
+    required this.focusNode,
+    required this.bodyFocusNode,
+  });
+
+  @override
+  State<_FocusableActionWrapper> createState() =>
+      _FocusableActionWrapperState();
+}
+
+class _FocusableActionWrapperState extends State<_FocusableActionWrapper> {
+  bool _focused = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
+    return Focus(
+      focusNode: widget.focusNode,
+      onFocusChange: (f) => setState(() => _focused = f),
+      onKeyEvent: (node, event) {
+        // Left from the download icon returns focus to the card body.
+        if ((event is KeyDownEvent || event is KeyRepeatEvent) &&
+            event.logicalKey == LogicalKeyboardKey.arrowLeft &&
+            widget.bodyFocusNode.canRequestFocus) {
+          widget.bodyFocusNode.requestFocus();
+          return KeyEventResult.handled;
+        }
+        return KeyEventResult.ignored;
+      },
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 120),
+        padding: const EdgeInsets.all(2),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(10),
+          color: _focused ? primary.withValues(alpha: 0.22) : null,
+          border: Border.all(
+            color: _focused ? primary : Colors.transparent,
+            width: 2,
+          ),
+          boxShadow: _focused
+              ? [
+                  BoxShadow(
+                    color: primary.withValues(alpha: 0.5),
+                    blurRadius: 10,
+                    spreadRadius: 1,
+                  ),
+                ]
+              : null,
+        ),
+        child: widget.child,
+      ),
     );
   }
 }

--- a/lib/features/explore/presentation/widgets/explore_carousel.dart
+++ b/lib/features/explore/presentation/widgets/explore_carousel.dart
@@ -31,11 +31,29 @@ class ExploreCarousel extends ConsumerStatefulWidget {
   ConsumerState<ExploreCarousel> createState() => _ExploreCarouselState();
 }
 
+// Intents used by the carousel's keyboard shortcuts. Defined at file scope so
+// they're const-constructible and stable across rebuilds.
+class _CarouselPrevIntent extends Intent {
+  const _CarouselPrevIntent();
+}
+
+class _CarouselNextIntent extends Intent {
+  const _CarouselNextIntent();
+}
+
+class _CarouselUpIntent extends Intent {
+  const _CarouselUpIntent();
+}
+
 class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
   final ValueNotifier<int> _currentIndexNotifier = ValueNotifier<int>(0);
   final CarouselSliderController _carouselController =
       CarouselSliderController();
   final ValueNotifier<double> _scrollOffset = ValueNotifier(0.0);
+  // Single anchor focus node so the carousel acts as ONE focus target on TV/
+  // keyboard. Otherwise each slide is independently focusable and pages cause
+  // focus to drop into the next row when slides unmount.
+  final FocusNode _carouselFocusNode = FocusNode(debugLabel: 'carousel_anchor');
 
   @override
   void initState() {
@@ -49,11 +67,21 @@ class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
     }
   }
 
+  void _activateCurrent() {
+    final movie = widget.movies[_currentIndexNotifier.value];
+    if (widget.onTap != null) {
+      widget.onTap!(movie);
+    } else {
+      _navigateToDetails(context, movie);
+    }
+  }
+
   @override
   void dispose() {
     widget.scrollController?.removeListener(_onParentScroll);
     _scrollOffset.dispose();
     _currentIndexNotifier.dispose();
+    _carouselFocusNode.dispose();
     super.dispose();
   }
 
@@ -69,19 +97,62 @@ class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
     final profile = ref.watch(deviceProfileProvider).asData?.value;
     final isTv = profile?.isTv ?? context.isTv;
 
-    return Focus(
-      canRequestFocus: false,
-      skipTraversal: true,
-      onKeyEvent: (node, event) {
-        if (event is KeyDownEvent &&
-            event.logicalKey == LogicalKeyboardKey.arrowUp) {
-          widget.onNavigateUp?.call();
-          return widget.onNavigateUp != null
-              ? KeyEventResult.handled
-              : KeyEventResult.ignored;
-        }
-        return KeyEventResult.ignored;
+    return FocusableActionDetector(
+      focusNode: _carouselFocusNode,
+      // Carousel is the landing focus target on Home for TV/keyboard. Without
+      // this the inner CardsWrapper(autoFocus:) is dead because slides are
+      // wrapped in ExcludeFocus, and the screen would mount with no focus.
+      autofocus: true,
+      mouseCursor: SystemMouseCursors.click,
+      // Arrow keys are wired as explicit Shortcuts/Actions at this level so
+      // they fire when _carouselFocusNode has focus. Using a nested
+      // Focus(onKeyEvent:) for arrows is unreliable here — that child Focus
+      // is a descendant of _carouselFocusNode, and key events only propagate
+      // UP from the focused node, so the child's handler never runs. Worse,
+      // unhandled arrow keys fall through to Flutter's default ScrollAction
+      // which then scrolls the outer vertical CustomScrollView — exactly the
+      // "Right pages carousel AND scrolls page vertically" bug we saw.
+      shortcuts: const <ShortcutActivator, Intent>{
+        SingleActivator(LogicalKeyboardKey.select): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.enter): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.space): ActivateIntent(),
+        SingleActivator(LogicalKeyboardKey.arrowLeft): _CarouselPrevIntent(),
+        SingleActivator(LogicalKeyboardKey.arrowRight): _CarouselNextIntent(),
+        SingleActivator(LogicalKeyboardKey.arrowUp): _CarouselUpIntent(),
       },
+      actions: <Type, Action<Intent>>{
+        ActivateIntent: CallbackAction<ActivateIntent>(
+          onInvoke: (_) {
+            _activateCurrent();
+            return null;
+          },
+        ),
+        _CarouselPrevIntent: CallbackAction<_CarouselPrevIntent>(
+          onInvoke: (_) {
+            _carouselController.previousPage(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.easeOut,
+            );
+            return null;
+          },
+        ),
+        _CarouselNextIntent: CallbackAction<_CarouselNextIntent>(
+          onInvoke: (_) {
+            _carouselController.nextPage(
+              duration: const Duration(milliseconds: 350),
+              curve: Curves.easeOut,
+            );
+            return null;
+          },
+        ),
+        _CarouselUpIntent: CallbackAction<_CarouselUpIntent>(
+          onInvoke: (_) {
+            widget.onNavigateUp?.call();
+            return null;
+          },
+        ),
+      },
+      onShowFocusHighlight: (_) => setState(() {}),
       child: SizedBox(
         height: heroHeight,
         child: Stack(
@@ -104,7 +175,10 @@ class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
             ),
             itemBuilder: (context, index, realIndex) {
               final movie = widget.movies[index];
-              return _buildCarouselItem(context, movie, heroHeight, index);
+              // Slides are visual only — the carousel anchor handles focus.
+              return ExcludeFocus(
+                child: _buildCarouselItem(context, movie, heroHeight, index),
+              );
             },
           ),
 
@@ -274,7 +348,8 @@ class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
     }
 
     return CardsWrapper(
-      autoFocus: index == 0,
+      // Slides are wrapped in ExcludeFocus above; the carousel anchor owns
+      // focus, so no autoFocus here.
       onTap: () {
         if (widget.onTap != null) {
           widget.onTap!(movie);
@@ -438,10 +513,10 @@ class _ExploreCarouselState extends ConsumerState<ExploreCarousel> {
     int index,
   ) {
     return CardsWrapper(
-      autoFocus: index == 0,
+      // Slides are wrapped in ExcludeFocus above; the carousel anchor owns
+      // focus, so no autoFocus here.
       onTap: () {
         if (widget.onTap != null) {
-          // Need to access widget.onTap but this method is in state, so it works.
           widget.onTap!(movie);
         } else {
           _navigateToDetails(context, movie);

--- a/lib/features/settings/presentation/widgets/settings_widgets.dart
+++ b/lib/features/settings/presentation/widgets/settings_widgets.dart
@@ -41,7 +41,7 @@ class SettingsGroup extends StatelessWidget {
   }
 }
 
-class SettingsTile extends StatelessWidget {
+class SettingsTile extends StatefulWidget {
   final IconData icon;
   final String title;
   final String? subtitle;
@@ -60,47 +60,87 @@ class SettingsTile extends StatelessWidget {
   });
 
   @override
+  State<SettingsTile> createState() => _SettingsTileState();
+}
+
+class _SettingsTileState extends State<SettingsTile> {
+  bool _isFocused = false;
+
+  @override
   Widget build(BuildContext context) {
+    final primary = Theme.of(context).colorScheme.primary;
     return Column(
       children: [
-        ListTile(
-          focusColor: Theme.of(
-            context,
-          ).colorScheme.primary.withValues(alpha: 0.15),
-          leading: Container(
-            padding: const EdgeInsets.all(LayoutConstants.spacingXs),
+        Focus(
+          // Passive observer — we want the inner ListTile's InkWell to remain
+          // the actual focus target (it's what handles onTap when OK is
+          // pressed). hasFocus on this node reflects "any descendant focused"
+          // so onFocusChange still fires when the tile is reached.
+          canRequestFocus: false,
+          skipTraversal: true,
+          onFocusChange: (f) {
+            setState(() => _isFocused = f);
+            if (f) {
+              // Center the focused setting row in the viewport.
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                final ctx = FocusManager.instance.primaryFocus?.context;
+                final ro = ctx?.findRenderObject();
+                if (ctx != null && ctx.mounted && ro != null) {
+                  Scrollable.maybeOf(ctx)?.position.ensureVisible(
+                        ro,
+                        alignment: 0.5,
+                        duration: const Duration(milliseconds: 380),
+                        curve: Curves.fastOutSlowIn,
+                      );
+                }
+              });
+            }
+          },
+          child: AnimatedContainer(
+            duration: const Duration(milliseconds: 150),
             decoration: BoxDecoration(
-              color: Theme.of(
-                context,
-              ).colorScheme.primary.withValues(alpha: 0.1),
-              borderRadius: BorderRadius.circular(8),
+              borderRadius: BorderRadius.circular(16),
+              color: _isFocused
+                  ? primary.withValues(alpha: 0.22)
+                  : Colors.transparent,
+              border: Border.all(
+                color: _isFocused ? primary : Colors.transparent,
+                width: 2,
+              ),
             ),
-            child: Icon(
-              icon,
-              color: Theme.of(context).colorScheme.primary,
-              size: 20,
+            child: ListTile(
+              focusColor: Colors.transparent,
+              hoverColor: primary.withValues(alpha: 0.10),
+              leading: Container(
+                padding: const EdgeInsets.all(LayoutConstants.spacingXs),
+                decoration: BoxDecoration(
+                  color: primary.withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(widget.icon, color: primary, size: 20),
+              ),
+              title: Text(
+                widget.title,
+                style: const TextStyle(fontWeight: FontWeight.w500),
+              ),
+              subtitle: widget.subtitle != null
+                  ? Text(
+                      widget.subtitle!,
+                      style: TextStyle(
+                        color: Theme.of(context).textTheme.bodySmall?.color,
+                      ),
+                    )
+                  : null,
+              trailing: widget.trailing ??
+                  const Icon(Icons.chevron_right_rounded, size: 20),
+              onTap: widget.onTap,
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(16),
+              ),
             ),
-          ),
-          title: Text(
-            title,
-            style: const TextStyle(fontWeight: FontWeight.w500),
-          ),
-          subtitle: subtitle != null
-              ? Text(
-                  subtitle!,
-                  style: TextStyle(
-                    color: Theme.of(context).textTheme.bodySmall?.color,
-                  ),
-                )
-              : null,
-          trailing:
-              trailing ?? const Icon(Icons.chevron_right_rounded, size: 20),
-          onTap: onTap,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(16),
           ),
         ),
-        if (!isLast)
+        if (!widget.isLast)
           Divider(
             height: 1,
             indent: 56,

--- a/lib/shared/widgets/app_scaffold.dart
+++ b/lib/shared/widgets/app_scaffold.dart
@@ -20,10 +20,10 @@ class AppScaffold extends ConsumerStatefulWidget {
 
 class _AppScaffoldState extends ConsumerState<AppScaffold> {
   // Owned here so the content-area LEFT key handler can focus them directly,
-  // crossing the Branch Navigator's FocusScope boundary.
-  static const _sidebarItemCount = 5;
+  // crossing the Branch Navigator's FocusScope boundary. Count comes from
+  // [kSidebarDestinationCount] in app_sidebar.dart — single source of truth.
   late final List<FocusNode> _sidebarNodes = List.generate(
-    _sidebarItemCount,
+    kSidebarDestinationCount,
     (i) => FocusNode(debugLabel: 'sidebar_$i'),
   );
 
@@ -59,18 +59,38 @@ class _AppScaffoldState extends ConsumerState<AppScaffold> {
     }
   }
 
-  // Intercepts D-pad LEFT before DpadNavigator's CallbackShortcuts can consume
-  // it, because this Focus sits above the Branch Navigator in the focus tree.
-  // From inside the Branch scope, focusInDirection(left) can't reach the
-  // sidebar (different FocusScope), so we focus the sidebar item explicitly.
+  // Intercepts D-pad LEFT only when the currently focused widget has no
+  // focusable neighbour to the left within the content area. In that case we
+  // explicitly focus the sidebar item (different FocusScope, so directional
+  // traversal can't bridge it on its own). Otherwise we let the event continue
+  // so normal in-row navigation works.
   KeyEventResult _onContentKeyEvent(FocusNode node, KeyEvent event) {
-    if (event is KeyDownEvent &&
-        event.logicalKey == LogicalKeyboardKey.arrowLeft) {
-      final idx = widget.navigationShell.currentIndex;
-      _sidebarNodes[idx].requestFocus();
+    if (event is! KeyDownEvent && event is! KeyRepeatEvent) {
+      return KeyEventResult.ignored;
+    }
+    if (event.logicalKey != LogicalKeyboardKey.arrowLeft) {
+      return KeyEventResult.ignored;
+    }
+    final primary = FocusManager.instance.primaryFocus;
+    if (primary == null) return KeyEventResult.ignored;
+
+    final moved = primary.focusInDirection(TraversalDirection.left);
+    if (moved) {
       return KeyEventResult.handled;
     }
-    return KeyEventResult.ignored;
+    // No focusable to the left in this scope — fall back to sidebar. Bail
+    // back to ignored if the target node is out of range or unfocusable so
+    // we don't silently swallow the Left key when focus can't move.
+    final idx = widget.navigationShell.currentIndex;
+    if (idx < 0 || idx >= _sidebarNodes.length) {
+      return KeyEventResult.ignored;
+    }
+    final target = _sidebarNodes[idx];
+    if (!target.canRequestFocus) {
+      return KeyEventResult.ignored;
+    }
+    target.requestFocus();
+    return KeyEventResult.handled;
   }
 
   @override

--- a/lib/shared/widgets/app_sidebar.dart
+++ b/lib/shared/widgets/app_sidebar.dart
@@ -2,6 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:skystream/l10n/generated/app_localizations.dart';
 
+/// Number of destinations rendered by [AppSidebar]. Used by [AppScaffold] to
+/// size its own FocusNode list so the two stay in sync — change this and the
+/// destinations list together.
+const int kSidebarDestinationCount = 5;
+
 class AppSidebar extends StatelessWidget {
   final int currentIndex;
   final ValueChanged<int> onItemTapped;
@@ -28,6 +33,14 @@ class AppSidebar extends StatelessWidget {
       (Icons.library_books_outlined, Icons.library_books, l10n.library),
       (Icons.settings_outlined, Icons.settings, l10n.settings),
     ];
+    assert(
+      destinations.length == kSidebarDestinationCount,
+      'kSidebarDestinationCount must match the destinations list length',
+    );
+    assert(
+      focusNodes.length == destinations.length,
+      'Sidebar focusNodes count must match destinations count',
+    );
 
     return Material(
       color: bgColor,

--- a/lib/shared/widgets/cards_wrapper.dart
+++ b/lib/shared/widgets/cards_wrapper.dart
@@ -51,6 +51,15 @@ class _CardsWrapperState extends State<CardsWrapper>
   }
 
   @override
+  void didUpdateWidget(covariant CardsWrapper oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.focusNode != oldWidget.focusNode) {
+      if (oldWidget.focusNode == null) _node.dispose();
+      _node = widget.focusNode ?? FocusNode();
+    }
+  }
+
+  @override
   void dispose() {
     _controller.dispose();
     if (widget.focusNode == null) _node.dispose();
@@ -77,6 +86,43 @@ class _CardsWrapperState extends State<CardsWrapper>
       _isFocused = hasFocus;
     });
     _updateAnimation();
+    if (hasFocus) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        final ro = context.findRenderObject();
+        if (ro is! RenderBox || !ro.hasSize) return;
+        const duration = Duration(milliseconds: 380);
+        const curve = Curves.fastOutSlowIn;
+
+        // Horizontal: always center the focused card inside its row so the
+        // active card stays in the middle of the screen as the user walks
+        // along the row.
+        Scrollable.maybeOf(context, axis: Axis.horizontal)
+            ?.position
+            .ensureVisible(ro, alignment: 0.5, duration: duration, curve: curve);
+
+        // Vertical: only scroll if the card is actually clipped. Moving
+        // Left/Right within a row would otherwise re-center the row
+        // vertically on every keystroke and the whole screen would jump.
+        final vScroll = Scrollable.maybeOf(context, axis: Axis.vertical);
+        if (vScroll != null) {
+          final scrollBox = vScroll.context.findRenderObject();
+          if (scrollBox is RenderBox && scrollBox.hasSize) {
+            final top = ro.localToGlobal(Offset.zero, ancestor: scrollBox).dy;
+            final bottom = top + ro.size.height;
+            final viewportH = scrollBox.size.height;
+            if (top < 0 || bottom > viewportH) {
+              vScroll.position.ensureVisible(
+                ro,
+                alignment: 0.5,
+                duration: duration,
+                curve: curve,
+              );
+            }
+          }
+        }
+      });
+    }
   }
 
   void _onHover(bool isHovered) {

--- a/lib/shared/widgets/custom_widgets.dart
+++ b/lib/shared/widgets/custom_widgets.dart
@@ -105,15 +105,17 @@ class _CustomSliderState extends State<CustomSlider> {
           return KeyEventResult.handled;
         }
 
-        // Up arrow: move focus up
+        // Up arrow: move focus up — operate on our own node so traversal is
+        // anchored to the slider and not to whatever happens to be the
+        // enclosing FocusScope.
         if (logicalKey == LogicalKeyboardKey.arrowUp) {
-          FocusScope.of(context).focusInDirection(TraversalDirection.up);
+          _focusNode.focusInDirection(TraversalDirection.up);
           return KeyEventResult.handled;
         }
 
         // Down arrow: move focus down
         if (logicalKey == LogicalKeyboardKey.arrowDown) {
-          FocusScope.of(context).focusInDirection(TraversalDirection.down);
+          _focusNode.focusInDirection(TraversalDirection.down);
           return KeyEventResult.handled;
         }
 
@@ -199,15 +201,17 @@ class _CustomTextFieldState extends State<CustomTextField> {
 
         final key = event.logicalKey;
 
-        // Up arrow: move focus to previous element
+        // Use directional traversal anchored to our own node so D-pad Up/Down
+        // lands on the spatial neighbour. The previous unfocus/disable/
+        // re-enable dance relied on a 100ms timer that could race on slow
+        // devices and re-focus the field instead of moving on.
         if (key == LogicalKeyboardKey.arrowUp) {
-          _moveFocusPrevious();
+          _focusNode.focusInDirection(TraversalDirection.up);
           return KeyEventResult.handled;
         }
 
-        // Down arrow: move focus to next element
         if (key == LogicalKeyboardKey.arrowDown) {
-          _moveFocusNext();
+          _focusNode.focusInDirection(TraversalDirection.down);
           return KeyEventResult.handled;
         }
 
@@ -215,38 +219,6 @@ class _CustomTextFieldState extends State<CustomTextField> {
         return KeyEventResult.ignored;
       },
     );
-  }
-
-  void _moveFocusNext() {
-    // Temporarily make this node non-focusable to prevent cycling back
-    _focusNode.unfocus();
-    _focusNode.canRequestFocus = false;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        FocusScope.of(context).nextFocus();
-        // Re-enable focus after a delay
-        Future.delayed(const Duration(milliseconds: 100), () {
-          if (mounted) _focusNode.canRequestFocus = true;
-        });
-      }
-    });
-  }
-
-  void _moveFocusPrevious() {
-    // Temporarily make this node non-focusable to prevent cycling back
-    _focusNode.unfocus();
-    _focusNode.canRequestFocus = false;
-
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (mounted) {
-        FocusScope.of(context).previousFocus();
-        // Re-enable focus after a delay
-        Future.delayed(const Duration(milliseconds: 100), () {
-          if (mounted) _focusNode.canRequestFocus = true;
-        });
-      }
-    });
   }
 
   @override
@@ -292,10 +264,12 @@ class _CustomTextFieldState extends State<CustomTextField> {
       obscureText: widget.obscureText,
       keyboardType: widget.keyboardType,
       onSubmitted: (value) {
-        // Call user callback first
+        // Call user callback first — it may navigate away or close a host
+        // dialog, so bail out if we got unmounted before moving focus.
         widget.onSubmitted?.call(value);
-        // Then move focus to next element (the buttons)
-        _moveFocusNext();
+        if (mounted) {
+          _focusNode.focusInDirection(TraversalDirection.down);
+        }
       },
     );
   }
@@ -331,18 +305,24 @@ class CustomButton extends StatefulWidget {
 class _CustomButtonState extends State<CustomButton> {
   late FocusNode _focusNode;
   bool _isFocused = false;
+  late final VoidCallback _focusListener;
 
   @override
   void initState() {
     super.initState();
     _focusNode = widget.focusNode ?? FocusNode();
-    _focusNode.addListener(() {
+    _focusListener = () {
       if (mounted) setState(() => _isFocused = _focusNode.hasFocus);
-    });
+    };
+    _focusNode.addListener(_focusListener);
   }
 
   @override
   void dispose() {
+    // Always remove the listener; the node may be owned by the parent, in
+    // which case it outlives this state and would otherwise hold a reference
+    // to a disposed closure target.
+    _focusNode.removeListener(_focusListener);
     if (widget.focusNode == null) {
       _focusNode.dispose();
     }
@@ -355,15 +335,23 @@ class _CustomButtonState extends State<CustomButton> {
     final isTraditional = FocusManager.instance.highlightMode == FocusHighlightMode.traditional;
     final showHighlight = _isFocused && isTraditional;
 
-    // Use Material 3 button with custom focus highlight
+    // Wrap in an AnimatedScale + Container so focused buttons get a clear
+    // "elevation" cue regardless of their fill color. Useful on TV where blue
+    // and grey buttons can otherwise look identical to non-focused.
+    final scale = showHighlight ? 1.04 : 1.0;
+    final glowColor = primaryColor;
+
+    Widget core;
     if (widget.isPrimary) {
-      return FilledButton(
+      core = FilledButton(
         focusNode: _focusNode,
         autofocus: widget.autofocus,
         onPressed: widget.onPressed,
         style: FilledButton.styleFrom(
           backgroundColor: showHighlight
-              ? primaryColor.withValues(alpha: 0.9)
+              // On focus, brighten the primary fill so it pops against the dark
+              // background and the white outline contrasts clearly.
+              ? Color.lerp(primaryColor, Colors.white, 0.18)
               : (widget.backgroundColor ?? primaryColor),
           foregroundColor: Theme.of(context).colorScheme.onPrimary,
           disabledBackgroundColor: Theme.of(
@@ -380,30 +368,54 @@ class _CustomButtonState extends State<CustomButton> {
         ),
         child: widget.child,
       );
+    } else {
+      core = TextButton(
+        focusNode: _focusNode,
+        autofocus: widget.autofocus,
+        onPressed: widget.onPressed,
+        style: TextButton.styleFrom(
+          backgroundColor: showHighlight
+              // Fill the button on focus so a "grey" outlined button no longer
+              // looks identical to its non-focused state.
+              ? primaryColor.withValues(alpha: 0.28)
+              : null,
+          foregroundColor: _isFocused
+              ? Theme.of(context).colorScheme.onPrimary
+              : Theme.of(context).colorScheme.onSurfaceVariant,
+          disabledForegroundColor: Theme.of(
+            context,
+          ).colorScheme.onSurface.withValues(alpha: 0.38),
+          side: showHighlight
+              ? const BorderSide(color: Colors.white, width: 3)
+              : (widget.isOutlined
+                    ? BorderSide(color: Theme.of(context).colorScheme.outline)
+                    : BorderSide.none),
+          shape: widget.shape,
+        ),
+        child: widget.child,
+      );
     }
 
-    return TextButton(
-      focusNode: _focusNode,
-      autofocus: widget.autofocus,
-      onPressed: widget.onPressed,
-      style: TextButton.styleFrom(
-        backgroundColor: showHighlight
-            ? primaryColor.withValues(alpha: 0.15)
-            : null,
-        foregroundColor: _isFocused
-            ? primaryColor
-            : Theme.of(context).colorScheme.onSurfaceVariant,
-        disabledForegroundColor: Theme.of(
-          context,
-        ).colorScheme.onSurface.withValues(alpha: 0.38),
-        side: showHighlight
-            ? const BorderSide(color: Colors.white, width: 2)
-            : (widget.isOutlined
-                  ? BorderSide(color: Theme.of(context).colorScheme.outline)
-                  : BorderSide.none),
-        shape: widget.shape,
+    return AnimatedScale(
+      duration: const Duration(milliseconds: 150),
+      curve: Curves.easeOut,
+      scale: scale,
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 150),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: showHighlight
+              ? [
+                  BoxShadow(
+                    color: glowColor.withValues(alpha: 0.55),
+                    blurRadius: 16,
+                    spreadRadius: 1,
+                  ),
+                ]
+              : null,
+        ),
+        child: core,
       ),
-      child: widget.child,
     );
   }
 }

--- a/lib/shared/widgets/focusable_item.dart
+++ b/lib/shared/widgets/focusable_item.dart
@@ -58,6 +58,42 @@ class _FocusableItemState extends State<FocusableItem>
     }
   }
 
+  void _scrollIntoViewOnFocus() {
+    // Mirror CardsWrapper: keep the focused item centered horizontally in
+    // its scrollable row; only adjust the vertical scroll when the item is
+    // actually clipped, otherwise Left/Right within a visible row would
+    // re-center the row vertically on every keystroke.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final ro = context.findRenderObject();
+      if (ro is! RenderBox || !ro.hasSize) return;
+      const duration = Duration(milliseconds: 380);
+      const curve = Curves.fastOutSlowIn;
+
+      Scrollable.maybeOf(context, axis: Axis.horizontal)
+          ?.position
+          .ensureVisible(ro, alignment: 0.5, duration: duration, curve: curve);
+
+      final vScroll = Scrollable.maybeOf(context, axis: Axis.vertical);
+      if (vScroll != null) {
+        final scrollBox = vScroll.context.findRenderObject();
+        if (scrollBox is RenderBox && scrollBox.hasSize) {
+          final top = ro.localToGlobal(Offset.zero, ancestor: scrollBox).dy;
+          final bottom = top + ro.size.height;
+          final viewportH = scrollBox.size.height;
+          if (top < 0 || bottom > viewportH) {
+            vScroll.position.ensureVisible(
+              ro,
+              alignment: 0.5,
+              duration: duration,
+              curve: curve,
+            );
+          }
+        }
+      }
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return FocusableActionDetector(
@@ -66,6 +102,7 @@ class _FocusableItemState extends State<FocusableItem>
           _isFocused = focused;
         });
         _updateState();
+        if (focused) _scrollIntoViewOnFocus();
       },
       onShowHoverHighlight: (hovered) {
         setState(() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 2.3.0+1
+version: 2.3.2+1
 
 environment:
   sdk: ^3.11.4


### PR DESCRIPTION
## Summary

Continues `tv-dpad-navigation` to close out the remaining D-pad navigation bugs and polish focus visuals across non-player surfaces. Per the maintainer's scope note in #30, this is the merged **PR 1 + PR 2** (Home / Explore / Library + Settings / Extensions). Player (PR 3) and media-key polish (PR 4) are deferred.

Closes #30. Substantially addresses #38.

Tested on Fire TV (Fire OS, Android 9, `armeabi-v7a`). Universal-coverage check passes on macOS desktop via Tab + arrow keys.

## Changes

**Scaffold / global**
- `app_scaffold`: directional Left no longer always yanks focus to the sidebar — only at the leftmost edge of content. Bails to `KeyEventResult.ignored` when the sidebar target isn't focusable so the key isn't silently swallowed.
- `app_sidebar`: exports `kSidebarDestinationCount` so the count is a single source of truth + asserts focusNode parity.

**Carousel (Home / Explore hero)**
- Whole carousel is one focus target via `FocusableActionDetector` with `autofocus: true` so Home lands with focus on TV/keyboard.
- Arrow keys wired through `shortcuts`/`actions` (Intent classes at file scope) instead of a nested `Focus(onKeyEvent:)`. The nested Focus was a descendant of the focused node in the focus tree and its handler never fired — unhandled arrows fell through to Flutter's default `ScrollAction`, scrolling the outer `CustomScrollView` vertically while paging horizontally.
- Inner slides wrapped in `ExcludeFocus` so paging doesn't drop focus down to the next row.

**Update dialog**
- "Update Now" `FilledButton` autofocuses so remote input lands inside the dialog instead of passing through to UI behind it.

**Settings**
- `SettingsTile` rebuilt with a passive outer `Focus` (`canRequestFocus: false, skipTraversal: true`) + primary-tinted highlight + 2px border + smooth center-on-focus scroll. The inner `ListTile.InkWell` remains the real focus target so OK fires `onTap`.

**Custom widgets**
- `CustomButton`: stronger D-pad focus visual (brighter fill, 3px white outline, primary-tinted glow, 1.04x scale). FocusNode listener stored as a field and removed on dispose so externally provided nodes don't accumulate stale listeners.
- `CustomTextField`: replaced the unfocus / `canRequestFocus = false` / 100ms-delay / re-enable dance with `focusInDirection(up|down)` on the field's own node. The old approach was racy on Fire TV armv7 and used Tab order instead of spatial traversal. `onSubmitted` checks `mounted` after the user callback before moving focus.
- `CustomSlider`: D-pad Up/Down uses the slider's own `_focusNode.focusInDirection(...)` instead of the enclosing FocusScope.

**Details**
- AppBar back + bookmark wrapped in `Focus(descendantsAreTraversable: false)` so body-content directional traversal doesn't escape upward. Mouse/touch unaffected; hardware Back handles back navigation.
- **New Library button in the synopsis action row** — gives D-pad users a focusable bookmark target (the AppBar one is intentionally unreachable). Filled bookmark icon when in library, outlined when not.
- Episode card is a single focus pill. Menu (≡) / F10 / long-press OK trigger the download flow; the download icon has its own visible focus + explicit Left handler back to the body.

**Center-on-focus polish**
- `CardsWrapper` + `FocusableItem` (Continue Watching): horizontal axis always centers the focused card; vertical only fires when the card is actually clipped, so Left/Right within a visible row doesn't re-center the row vertically on every keystroke.
- `CardsWrapper` also handles a `focusNode` swap in `didUpdateWidget`.

**Version**
- Bumped `pubspec.yaml` to `2.3.2+1` so the in-app update dialog stops nagging this branch (which was based off an older 2.3.0 commit while `upstream/main` already cut v2.3.2).

## Known follow-ups (not in this PR)
- "Add repo" focus bug in Extension Manager — reported but no reproducer yet
- Global "always-one-focused" recovery via `FocusManager` listener
- Settings cleanup pass (separate issue)
- Responsive poster sizing on TV — pure visual polish

## Test plan
- Build debug APK for `armeabi-v7a`, sideload to a Fire TV, walk every screen with the remote only:
  - Sidebar: Up/Down across items; Right enters content; Left from leftmost content returns to sidebar; Left mid-row moves within the row.
  - Carousel: Left/Right pages slides without scrolling the page vertically; OK opens the visible slide; Up exits to the AppBar; Down drops to next row.
  - Card rows: D-pad walks cards; focused card centers horizontally; new rows scroll into view only when off-screen.
  - Continue Watching: same centering behaviour as regular card rows.
  - Details: Play / Download / Library buttons have unmistakable focus visual; OK fires action; episode pill activates Play on OK, Menu opens download.
  - Settings: each row has bold tint + border + glow; OK activates dialog/toggle; rows scroll smoothly to center.
  - Update dialog: appears focused on Update Now; Left/Right toggles to Later.
- macOS / desktop: Tab walks all focusable widgets in reading order; arrow keys move directionally where set up; Enter activates focused buttons; no widgets unreachable via keyboard.
- Confirm the update dialog no longer appears on launch with the bumped version.

