### PR TITLE
fix: restore star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,11 +234,11 @@ SkyStream is a streaming client and does not host any content. All media is stre
 
 ## Star History
 
-<a href="https://www.star-history.com/#akashdh11/skystream&Date">
+<a href="https://star-history.dera.page/#akashdh11/skystream&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=akashdh11/skystream&type=date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=akashdh11/skystream&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=akashdh11/skystream&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=akashdh11/skystream&type=date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=akashdh11/skystream&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=akashdh11/skystream&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart is currently broken because of GitHub stargazer API restrictions. This fixes it by switching to the star-history.dera.page fork, which uses another data source and requires no API token, so the chart works again.